### PR TITLE
add environment file to make binder work

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - geopandas
   - shapely
   - matplotlib
+  - descartes

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: my_environment
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - geopandas
+  - shapely

--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,4 @@ channels:
 dependencies:
   - geopandas
   - shapely
+  - matplotlib


### PR DESCRIPTION
Your project didn't have an environment file so didn't work on binder. This pull request adds one.